### PR TITLE
Fix arrows on previous and next posts links

### DIFF
--- a/src/themes/osprey/layouts/_default/single.html
+++ b/src/themes/osprey/layouts/_default/single.html
@@ -14,10 +14,10 @@
 
             <div class="links">
                 {{ if .PrevInSection }}
-                    &laquo; <a class="basic-alignment left" href="{{ .PrevInSection.Permalink }}">{{ .PrevInSection.Title }}</a>
+                    <span>&laquo;&nbsp;<a class="basic-alignment left" href="{{ .PrevInSection.Permalink }}">{{ .PrevInSection.Title }}</a></span>
                 {{ end }}
                 {{ if .NextInSection }}
-                    <a class="basic-alignment left" href="{{ .NextInSection.Permalink }}">{{ .NextInSection.Title }}</a> &raquo;
+                    <span><a class="basic-alignment left" href="{{ .NextInSection.Permalink }}">{{ .NextInSection.Title }}</a>&nbsp;&raquo;</span>
                 {{ end }}
             </div>
         </section>


### PR DESCRIPTION
Hi Aaron 👋,

I noticed the arrows on the next post link is currently playing a bit funny:

![before](https://user-images.githubusercontent.com/6102639/45337171-1aa76780-b5ca-11e8-947d-74ce5652dc6d.png)

I believe that change should fix it with a minor change and not change how they stack when the width isn't enough to accomodate both titles:

![after-with-titles-side-by-side](https://user-images.githubusercontent.com/6102639/45337229-5a6e4f00-b5ca-11e8-9def-15d9ade46b54.png)

![after-with-titles-stacked](https://user-images.githubusercontent.com/6102639/45337262-71ad3c80-b5ca-11e8-8a8e-d7fd7a512fb3.png)

Let me know what you think ✌
