### PR TITLE
Fix light mode card contrast

### DIFF
--- a/src/themes/aaronpowell/assets/sass/main.scss
+++ b/src/themes/aaronpowell/assets/sass/main.scss
@@ -35,17 +35,6 @@
     }
 }
 
-:root {
-    color-scheme: dark;
-    --surface: rgba(15, 23, 42, 0.85);
-    --surface-solid: #16213f;
-    --border-subtle: rgba(255, 255, 255, 0.08);
-    --shadow-soft: 0 25px 55px -25px rgba(15, 23, 42, 0.65);
-    --shadow-sharp: 0 25px 45px -15px rgba(15, 23, 42, 0.8);
-    --accent: #38bdf8;
-    --accent-strong: #0ea5e9;
-}
-
 *,
 *::before,
 *::after {


### PR DESCRIPTION
## Summary
- remove the forced dark theme CSS overrides on :root so light-mode tokens apply correctly
- improves legibility of post cards when viewing in light mode

## Testing
- hugo --source ./src --destination ../.output --buildDrafts --buildFuture