### PR TITLE
Fix code snippet controls and overflow

### DIFF
--- a/src/themes/aaronpowell/assets/js/script.js
+++ b/src/themes/aaronpowell/assets/js/script.js
@@ -78,27 +78,22 @@ document.addEventListener("DOMContentLoaded", function () {
                 copied.classList.add("copied");
                 copied.innerHTML = "✔";
 
-                const pre = codeBlock.parentNode;
-                if (pre.parentNode.classList.contains("highlight")) {
-                    const highlight = pre.parentNode;
-                    highlight.parentNode.insertBefore(button, highlight);
-                    highlight.parentNode.insertBefore(copied, highlight);
-                } else {
-                    pre.parentNode.insertBefore(button, pre);
-                    pre.parentNode.insertBefore(copied, pre);
-                }
+                const pre = codeBlock.parentElement;
+                const codeContainer = codeBlock.closest(".highlight") || pre;
+                codeContainer.parentNode.insertBefore(button, codeContainer);
+                codeContainer.parentNode.insertBefore(copied, codeContainer);
             });
     }
 
     function setupCopyBlock() {
         const copy = document.querySelectorAll(".copy");
         const handleCopy = async (e) => {
-            const item = e.target;
+            const item = e.currentTarget;
             const target = document.querySelector(item.dataset["target"]);
             await window.navigator.clipboard.writeText(
                 target.innerText.replace("\n\n", "\n")
             );
-            const copied = item.parentElement.querySelector(".copied");
+            const copied = item.nextElementSibling;
             copied.style.display = "inline";
             setTimeout(() => {
                 copied.style.display = "none";
@@ -273,6 +268,6 @@ document.addEventListener("DOMContentLoaded", function () {
                 sib.style.display = "none";
             }
         });
+
     }
 });
-

--- a/src/themes/aaronpowell/assets/sass/main.scss
+++ b/src/themes/aaronpowell/assets/sass/main.scss
@@ -352,6 +352,8 @@ pre {
     font-variant-ligatures: common-ligatures;
     padding: 1.5rem;
     margin: 0;
+    max-width: 100%;
+    overflow-x: auto;
 }
 
 code {
@@ -393,18 +395,18 @@ code {
 }
 
 .copy.code {
-    display: inline-flex;
+    display: flex;
     align-items: center;
     justify-content: center;
     gap: 0.35rem;
-    float: right;
+    width: fit-content;
     padding: 0.45rem 0.85rem;
     border: 1px solid var(--copy-button-border, rgba(148, 163, 184, 0.3));
     border-radius: 999px;
     background: var(--copy-button-bg, rgba(15, 23, 42, 0.8));
     box-shadow: inset 0 0 0 1px
         var(--copy-button-shadow, rgba(56, 189, 248, 0.15));
-    margin: 0.65rem 0 0.65rem 0.65rem;
+    margin: 0.65rem 0 0.65rem auto;
 }
 
 .copied {


### PR DESCRIPTION
## Summary
- place fenced-code copy controls beside the full Hugo highlight container so line-number markup cannot trap them inside the code table
- align copy controls to the hard-right edge with consistent spacing
- add horizontal scrolling to language-less fenced blocks
- associate copied feedback with the button that was activated

## Validation
- built the Hugo site with Hugo Extended 0.164.0
- inspected desktop and mobile layouts with Playwright at `http://localhost:4014`
- verified copy controls align with the highlight edge and per-block feedback targets the correct snippet