### PR TITLE
Modernize site search with Pagefind

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,7 +1,6 @@
 name: Build and deploy (Core)
 env:
   OUTPUT_FOLDER: hugo-output
-  DOTNET_VERSION: "9.x"
 
 on:
   workflow_call:
@@ -44,6 +43,9 @@ jobs:
         if: success()
         run: node ./scripts/compress-images.js --input "${{ github.workspace }}/${{ env.OUTPUT_FOLDER }}"
 
+      - name: Build search index
+        run: npx --yes pagefind@1.4.0 --site "${{ github.workspace }}/${{ env.OUTPUT_FOLDER }}"
+
       - name: Publish website output
         uses: actions/upload-artifact@v4
         with:
@@ -81,59 +83,8 @@ jobs:
           name: api
           path: ${{ github.workspace }}/${{ env.OUTPUT_FOLDER }}/api.tar
 
-  build_search_ui:
-    runs-on: ubuntu-latest
-    environment: build
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-
-      - name: Build search app
-        run: dotnet build --configuration Release
-        working-directory: ./Search
-
-      - name: Publish search UI
-        run: dotnet publish --no-build --configuration Release --output ${{ github.workspace }}/${{ env.OUTPUT_FOLDER }}
-        working-directory: ./Search/Search.Site.UI
-
-      - name: Package search UI
-        uses: actions/upload-artifact@v4
-        with:
-          name: search
-          path: ${{ github.workspace }}/${{ env.OUTPUT_FOLDER }}/wwwroot/_framework
-
-  build_search_index:
-    runs-on: ubuntu-latest
-    needs: build_hugo
-    environment: build
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-
-      - name: Download index source
-        uses: actions/download-artifact@v4
-        with:
-          name: json
-          path: ${{ github.workspace }}/${{ env.OUTPUT_FOLDER }}
-
-      - name: Build search index
-        run: dotnet run -- ${{ github.workspace }}/${{ env.OUTPUT_FOLDER }}/index.json
-        working-directory: ./Search/Search.IndexBuilder
-
-      - name: Publish search index
-        uses: actions/upload-artifact@v4
-        with:
-          name: search-index
-          path: ./Search/Search.IndexBuilder/index.zip
-
   provision:
-    needs: [build_search_ui, build_search_index, build_api]
+    needs: [build_hugo, build_api]
     runs-on: ubuntu-latest
     environment: production
     name: Provision Azure
@@ -201,18 +152,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: website
-          path: ${{ github.workspace }}/${{ env.OUTPUT_FOLDER }}
-
-      - name: Download search UI
-        uses: actions/download-artifact@v4
-        with:
-          name: search
-          path: ${{ github.workspace }}/${{ env.OUTPUT_FOLDER }}/_framework
-
-      - name: Download search index
-        uses: actions/download-artifact@v4
-        with:
-          name: search-index
           path: ${{ github.workspace }}/${{ env.OUTPUT_FOLDER }}
 
       - name: Download api

--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,1 @@
-hugo.exe --source "%cd%\src"  --destination "%cd%\.output" %*
+hugo.exe --source "%cd%\src" --destination "%cd%\.output" %* && npx --yes pagefind@1.4.0 --site "%cd%\.output"

--- a/src/config.toml
+++ b/src/config.toml
@@ -28,10 +28,6 @@ term = [ "HTML" ]
         name    = "Talks"
         url     = "talks"
         weight  = 4
-    [[menu.nav]]
-        name    = "Search"
-        url     = "search"
-        weight  = 5
 
 [markup]
   [markup.highlight]

--- a/src/content/search.md
+++ b/src/content/search.md
@@ -4,8 +4,4 @@ hidden: true
 layout: simple
 ---
 
-The following is an experiment in how to build a search index using [Blazor](https://dotnet.microsoft.com/apps/aspnet/web-apps/blazor?{{<cda>}}).
-
-<div id="app">Loading...</div>
-
-<script src="/_framework/blazor.webassembly.js"></script>
+Search is available from the site navigation.

--- a/src/themes/aaronpowell/assets/sass/nav.scss
+++ b/src/themes/aaronpowell/assets/sass/nav.scss
@@ -31,6 +31,7 @@
 .nav__brand {
     display: inline-flex;
     align-items: center;
+    flex-shrink: 0;
     gap: 0.85rem;
     color: var(--color-heading, #{$primaryHeaderColour});
     font-weight: 700;
@@ -123,6 +124,122 @@
 
 .nav__item {
     display: inline-flex;
+}
+
+.nav__search {
+    width: 220px;
+    max-width: 100%;
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.nav__search-fallback {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.35rem;
+    padding: 0.35rem 1rem;
+    border: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.35));
+    border-radius: 999px;
+    color: var(--nav-link, rgba(226, 232, 240, 0.85));
+    font-size: 0.95rem;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.nav__search-input {
+    width: 100%;
+    min-height: 2.35rem;
+    padding: 0.35rem 1rem;
+    border: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.35));
+    border-radius: 999px;
+    background: var(--surface-elevated, rgba(15, 23, 42, 0.55));
+    color: var(--nav-link, rgba(226, 232, 240, 0.85));
+    font: inherit;
+}
+
+.nav__search-results {
+    position: absolute;
+    top: calc(100% + 1rem);
+    right: 0;
+    width: 90vw;
+    max-width: 560px;
+    max-height: 36rem;
+    overflow-y: auto;
+    border: 1px solid var(--nav-menu-border, rgba(148, 163, 184, 0.2));
+    border-radius: $radius-lg;
+    background: var(--nav-menu-bg, rgba(10, 19, 36, 0.96));
+    box-shadow: var(--shadow-soft, 0 20px 40px -30px rgba(15, 23, 42, 0.7));
+}
+
+.nav__search-results:empty {
+    display: none;
+}
+
+.nav__search-result {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.85rem 1rem;
+    color: var(--color-text-primary, #{$primaryTextColour});
+}
+
+.nav__search-result + .nav__search-result {
+    border-top: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.18));
+}
+
+.nav__search-result span {
+    color: var(--color-text-secondary, rgba(226, 232, 240, 0.82));
+    font-size: 0.85rem;
+}
+
+.nav__search .pagefind-ui__search-input {
+    min-height: 2.35rem;
+    border-radius: 999px;
+    border: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.35));
+    background: var(--surface-elevated, rgba(15, 23, 42, 0.55));
+    color: var(--nav-link, rgba(226, 232, 240, 0.85));
+}
+
+.nav__search .pagefind-ui__search-clear {
+    color: var(--nav-link, rgba(226, 232, 240, 0.85));
+}
+
+.nav__search .pagefind-ui__drawer {
+    position: absolute;
+    top: calc(100% + 1rem);
+    right: 0;
+    width: 90vw;
+    max-width: 560px;
+    height: 70vh;
+    max-height: 36rem;
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid var(--nav-menu-border, rgba(148, 163, 184, 0.2));
+    border-radius: $radius-lg;
+    background: var(--nav-menu-bg, rgba(10, 19, 36, 0.96));
+    box-shadow: var(--shadow-soft, 0 20px 40px -30px rgba(15, 23, 42, 0.7));
+}
+
+.nav__search-results {
+    position: static;
+    width: 100%;
+    max-height: 24rem;
+}
+
+.nav__search .pagefind-ui__result-link,
+.nav__search .pagefind-ui__result-excerpt {
+    color: var(--color-text-primary, #{$primaryTextColour});
 }
 
 .nav__link {
@@ -248,7 +365,7 @@
     color: var(--color-text-primary, #{$primaryTextColour});
 }
 
-@media (max-width: $normal) {
+@media (max-width: $wide) {
     .nav__toggle {
         display: inline-flex;
     }
@@ -275,6 +392,16 @@
 
     .nav__item {
         width: 100%;
+    }
+
+    .nav__search {
+        width: 100%;
+    }
+
+    .nav__search .pagefind-ui__drawer {
+        position: static;
+        width: 100%;
+        max-height: 24rem;
     }
 
     .nav__item--action {
@@ -313,4 +440,3 @@
         font-size: 1rem;
     }
 }
-

--- a/src/themes/aaronpowell/assets/sass/nav.scss
+++ b/src/themes/aaronpowell/assets/sass/nav.scss
@@ -231,12 +231,6 @@
     box-shadow: var(--shadow-soft, 0 20px 40px -30px rgba(15, 23, 42, 0.7));
 }
 
-.nav__search-results {
-    position: static;
-    width: 100%;
-    max-height: 24rem;
-}
-
 .nav__search .pagefind-ui__result-link,
 .nav__search .pagefind-ui__result-excerpt {
     color: var(--color-text-primary, #{$primaryTextColour});
@@ -399,6 +393,12 @@
     }
 
     .nav__search .pagefind-ui__drawer {
+        position: static;
+        width: 100%;
+        max-height: 24rem;
+    }
+
+    .nav__search-results {
         position: static;
         width: 100%;
         max-height: 24rem;

--- a/src/themes/aaronpowell/layouts/_default/simple.html
+++ b/src/themes/aaronpowell/layouts/_default/simple.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 
-<section class="main">
+<section class="main" data-pagefind-ignore>
     <header>
         <div class="container">
             <h1>{{ .Title }}</h1>

--- a/src/themes/aaronpowell/layouts/_default/single.html
+++ b/src/themes/aaronpowell/layouts/_default/single.html
@@ -47,7 +47,7 @@
     </div>
     {{ end }}
 
-    <article class="article-surface">
+    <article class="article-surface" data-pagefind-body>
         {{ if isset .Params "image" }}
         <figure class="post-image">
             <img
@@ -90,4 +90,3 @@
 </footer>
 
 {{ end }}
-

--- a/src/themes/aaronpowell/layouts/partials/head.html
+++ b/src/themes/aaronpowell/layouts/partials/head.html
@@ -62,6 +62,9 @@
     rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}">
 
     <link rel="icon" href="{{ .Site.Params.favicon | absURL }}" />
+    {{ if not hugo.IsServer }}
+    <link href="{{ "pagefind/pagefind-ui.css" | absURL }}" rel="stylesheet" />
+    {{ end }}
     {{ $options := (dict "outputStyle" "compressed" "enableSourceMap" true) }}
     {{ $style := resources.Get "sass/main.scss" | css.Sass $options }}
     <link
@@ -71,4 +74,3 @@
         media="screen"
     />
 </head>
-

--- a/src/themes/aaronpowell/layouts/partials/header.html
+++ b/src/themes/aaronpowell/layouts/partials/header.html
@@ -1,5 +1,5 @@
 {{ $root := . }}
-<header class="site-header">
+<header class="site-header" data-pagefind-ignore>
     <div class="container">
         <nav class="nav" aria-label="Primary navigation">
             <a class="nav__brand" href="{{ $root.Site.BaseURL }}">
@@ -40,6 +40,19 @@
                     >
                 </li>
                 {{ end }}
+                <li class="nav__item nav__item--search">
+                    {{ if hugo.IsServer }}
+                    <form id="site-search" class="nav__search nav__dev-search">
+                        <label class="visually-hidden" for="site-search-input">Search</label>
+                        <input id="site-search-input" class="nav__search-input" type="search" placeholder="Search" autocomplete="off" />
+                        <div id="site-search-results" class="nav__search-results" aria-live="polite"></div>
+                    </form>
+                    {{ else }}
+                    <div id="site-search" class="nav__search">
+                        <a class="nav__search-fallback" href="{{ "search" | relURL }}">Search</a>
+                    </div>
+                    {{ end }}
+                </li>
                 <li class="nav__item nav__item--action">
                     <button
                         class="nav__theme-toggle"
@@ -76,3 +89,59 @@
         </nav>
     </div>
 </header>
+{{ if not hugo.IsServer }}
+<script src="{{ "pagefind/pagefind-ui.js" | absURL }}"></script>
+<script>
+    if (window.PagefindUI) {
+        new PagefindUI({ element: "#site-search", showImages: false });
+        document.querySelector(".nav__search-fallback").hidden = true;
+    }
+</script>
+{{ else }}
+<script>
+    const devSearchInput = document.querySelector("#site-search-input");
+    const devSearchResults = document.querySelector("#site-search-results");
+
+    fetch("{{ "index.json" | relURL }}")
+        .then(response => response.json())
+        .then(data => {
+            const posts = data.posts || [];
+            devSearchInput.addEventListener("input", () => {
+                const term = devSearchInput.value.trim().toLowerCase();
+                devSearchResults.replaceChildren();
+
+                if (!term) {
+                    return;
+                }
+
+                posts
+                    .filter(post => [post.title, post.description, post.content, ...(post.tags || [])]
+                        .join(" ")
+                        .toLowerCase()
+                        .includes(term))
+                    .slice(0, 8)
+                    .forEach(post => {
+                        const result = document.createElement("a");
+                        result.className = "nav__search-result";
+                        result.href = post.url;
+
+                        const title = document.createElement("strong");
+                        title.textContent = post.title;
+                        result.append(title);
+
+                        if (post.description) {
+                            const description = document.createElement("span");
+                            description.textContent = post.description;
+                            result.append(description);
+                        }
+
+                        devSearchResults.append(result);
+                    });
+            });
+        })
+        .catch(() => {
+            devSearchInput.disabled = true;
+            devSearchInput.placeholder = "Search unavailable";
+        });
+</script>
+{{ end }}

--- a/src/themes/aaronpowell/layouts/partials/header.html
+++ b/src/themes/aaronpowell/layouts/partials/header.html
@@ -42,11 +42,11 @@
                 {{ end }}
                 <li class="nav__item nav__item--search">
                     {{ if hugo.IsServer }}
-                    <form id="site-search" class="nav__search nav__dev-search">
+                    <div id="site-search" class="nav__search nav__dev-search">
                         <label class="visually-hidden" for="site-search-input">Search</label>
                         <input id="site-search-input" class="nav__search-input" type="search" placeholder="Search" autocomplete="off" />
                         <div id="site-search-results" class="nav__search-results" aria-live="polite"></div>
-                    </form>
+                    </div>
                     {{ else }}
                     <div id="site-search" class="nav__search">
                         <a class="nav__search-fallback" href="{{ "search" | relURL }}">Search</a>

--- a/src/themes/aaronpowell/layouts/talks/single.html
+++ b/src/themes/aaronpowell/layouts/talks/single.html
@@ -14,7 +14,7 @@
         </div>
     </header>
     <section class="container">
-        <article>
+        <article data-pagefind-body>
             <h2>Title</h2>
             <h3>{{ .Title }}</h3>
 


### PR DESCRIPTION
## Why

The existing search depends on a separate Blazor WebAssembly and Lucene application, plus dedicated CI jobs and packaged artifacts. This makes the static site build and deployment more complex than necessary.

## What changed

- Replace the WASM/Lucene runtime and index pipeline with Pagefind indexing of the Hugo output.
- Add Pagefind search to the top navigation, with responsive styling and a development-mode fallback backed by Hugo's `index.json`.
- Remove the dedicated search UI and search-index CI jobs and artifacts.
- Mark blog posts and talks as searchable while excluding navigation chrome from indexed content.

## Notes

Production builds run Pagefind after Hugo generates the site. Hugo watch mode uses the JSON fallback because Pagefind assets are generated during the production indexing step.