### PR TITLE
fix: make the header search responsive

### DIFF
--- a/src/themes/aaronpowell/assets/js/script.js
+++ b/src/themes/aaronpowell/assets/js/script.js
@@ -52,7 +52,7 @@ document.addEventListener("DOMContentLoaded", function () {
         });
 
         window
-            .matchMedia("(min-width: 992px)")
+            .matchMedia("(min-width: 1401px)")
             .addEventListener("change", () => {
                 closeMenu();
             });

--- a/src/themes/aaronpowell/assets/js/script.js
+++ b/src/themes/aaronpowell/assets/js/script.js
@@ -52,9 +52,11 @@ document.addEventListener("DOMContentLoaded", function () {
         });
 
         window
-            .matchMedia("(min-width: 1401px)")
-            .addEventListener("change", () => {
-                closeMenu();
+            .matchMedia("(max-width: 1400px)")
+            .addEventListener("change", (event) => {
+                if (!event.matches) {
+                    closeMenu();
+                }
             });
     }
 

--- a/src/themes/aaronpowell/assets/sass/nav.scss
+++ b/src/themes/aaronpowell/assets/sass/nav.scss
@@ -24,7 +24,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: clamp(1.25rem, 4vw, 2.5rem);
+    gap: 0.75rem;
     position: relative;
 }
 
@@ -116,7 +116,10 @@
 .nav__list {
     display: flex;
     align-items: center;
-    gap: clamp(1rem, 2.2vw, 1.75rem);
+    justify-content: flex-end;
+    flex: 1;
+    min-width: 0;
+    gap: clamp(0.7rem, 1.2vw, 1rem);
     list-style: none;
     margin: 0;
     padding: 0;
@@ -127,8 +130,12 @@
 }
 
 .nav__search {
-    width: 220px;
+    width: 175px;
     max-width: 100%;
+}
+
+.nav__item--search {
+    align-items: center;
 }
 
 .visually-hidden {
@@ -204,11 +211,15 @@
 }
 
 .nav__search .pagefind-ui__search-input {
+    box-sizing: border-box;
+    height: 2.35rem;
     min-height: 2.35rem;
+    padding: 0.35rem 2.75rem;
     border-radius: 999px;
     border: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.35));
     background: var(--surface-elevated, rgba(15, 23, 42, 0.55));
     color: var(--nav-link, rgba(226, 232, 240, 0.85));
+    line-height: 1.2;
 }
 
 .nav__search .pagefind-ui__search-clear {
@@ -345,6 +356,7 @@
     background-repeat: no-repeat;
     background-position: right 0.7rem center;
     padding-right: 2rem;
+    width: 115px;
 }
 
 .nav__font-picker-select:hover,
@@ -359,7 +371,7 @@
     color: var(--color-text-primary, #{$primaryTextColour});
 }
 
-@media (max-width: $wide) {
+@media (max-width: 1400px) {
     .nav__toggle {
         display: inline-flex;
     }


### PR DESCRIPTION
The deployed header was taller than intended because Pagefind's default search input sizing made the search item grow to two rows, while the full navigation also overflowed at common laptop widths.

This adjusts the header layout by:

- Normalizing the Pagefind input height and padding to match the other controls
- Reducing desktop control widths and spacing so the navigation stays within its container
- Switching to the compact menu before the header starts to overflow
- Keeping the JavaScript breakpoint aligned with the CSS breakpoint

This is a presentation-only fix; search behavior is unchanged.